### PR TITLE
Issue #1: Argument labels '(String:)' do not match any available overloads

### DIFF
--- a/Alamofire-Weather-Starter/Alamofire-Weather/ForcastService.swift
+++ b/Alamofire-Weather-Starter/Alamofire-Weather/ForcastService.swift
@@ -16,10 +16,10 @@ class ForcastService
     init(APIKey: String)
     {
         self.forecastAPIKey = APIKey
-        forecastBaseURL = URL(String: "https://api.darksky.net/forecast/\(APIKey)")
+        forecastBaseURL = URL(string: "https://api.darksky.net/forecast/\(APIKey)")
     }
     func getCurrentWeather(latitude: Double, longitude: Double){
-        let forecastURL = URL(String: "\(forecastBaseURL)/\(latitude),\(longitude)")
+        let forecastURL = URL(string: "\(forecastBaseURL)/\(latitude),\(longitude)")
     }
 }
 


### PR DESCRIPTION
Fix: Fixed an external parameter name "URL(string: )" from capital to lowercase